### PR TITLE
Feature/orrego diego

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.PHONY: tools build test run clean help
+tools:
+	@echo "Verificando herramientas necesarias..."
+	@command -v curl >/dev/null 2>&1 || { echo "Error: curl no está instalado"; exit 1; }
+	@command -v dig >/dev/null 2>&1 || { echo "Error: dig no está instalado"; exit 1; }
+	@command -v ss >/dev/null 2>&1 || { echo "Error: ss no está instalado"; exit 1; }
+	@command -v nc >/dev/null 2>&1 || { echo "Error: nc no está instalado"; exit 1; }
+	@command -v awk >/dev/null 2>&1 || { echo "Error: awk no está instalado"; exit 1; }
+	@command -v grep >/dev/null 2>&1 || { echo "Error: grep no está instalado"; exit 1; }
+	@command -v sed >/dev/null 2>&1 || { echo "Error: sed no está instalado"; exit 1; }
+	@command -v cut >/dev/null 2>&1 || { echo "Error: cut no está instalado"; exit 1; }
+	@command -v sort >/dev/null 2>&1 || { echo "Error: sort no está instalado"; exit 1; }
+	@command -v uniq >/dev/null 2>&1 || { echo "Error: uniq no está instalado"; exit 1; }
+	@command -v tr >/dev/null 2>&1 || { echo "Error: tr no está instalado"; exit 1; }
+	@command -v tee >/dev/null 2>&1 || { echo "Error: tee no está instalado"; exit 1; }
+	@command -v find >/dev/null 2>&1 || { echo "Error: find no está instalado"; exit 1; }
+	@command -v systemctl >/dev/null 2>&1 || { echo "Error: systemctl no está instalado"; exit 1; }
+	@command -v journalctl >/dev/null 2>&1 || { echo "Error: journalctl no está instalado"; exit 1; }
+	@command -v ip >/dev/null 2>&1 || { echo "Error: ip no está instalado"; exit 1; }
+	@command -v rsync >/dev/null 2>&1 || { echo "Error: rsync no está instalado"; exit 1; }
+	@echo "Todas las herramientas necesarias están disponibles"
+
+build: 
+	@echo "Construyendo el proyecto..."
+
+test: 
+	@echo "Ejecutando pruebas..."
+
+run: 
+	@echo "Ejecutando la aplicación..."
+
+clean:
+	@echo "Limpiando archivos generados..."
+
+help:
+	@echo "Uso: make [target]"

--- a/docs/bitacora-sprint-1.md
+++ b/docs/bitacora-sprint-1.md
@@ -39,9 +39,44 @@ $ ./src/gestor_procesos.sh detener
 
 Se optó por usar archivos PID en `/tmp` para el control de procesos por ser una ubicación estándar temporal. Las funciones retornan códigos de salida específicos para facilitar el debugging. Se utilizó `readonly` para las variables globales garantizando inmutabilidad. El script está preparado para expansión en Sprint 2 donde se implementará el servicio web real.
 
+### Tareas Completadas - Diego Orrego Torrejon
+
+**Implementar Makefile con targets obligatorios**
+
+Se creó el archivo `Makefile` en la raíz del proyecto con todos los targets requeridos por la especificación. El archivo incluye 6 targets principales: `tools`, `build`, `test`, `run`, `clean` y `help`. El target `tools` es el más crítico ya que verifica la disponibilidad de todas las herramientas Unix requeridas: curl, dig, ss, nc, awk, grep, sed, cut, sort, uniq, tr, tee, find, systemctl, journalctl, ip y rsync.
+
+Comando ejecutado para verificar la implementación:
+```bash
+$ make tools
+Verificando herramientas necesarias...
+Todas las herramientas necesarias están disponibles
+
+$ make help
+Uso: make [target]
+```
+
+**Verificación de herramientas del sistema**
+
+El target `tools` implementa una verificación completa usando `command -v` para cada herramienta requerida. Si alguna herramienta no está disponible, el proceso se detiene con código de salida 1 y un mensaje descriptivo. Esta implementación garantiza que el entorno cumple con todos los requisitos antes de ejecutar otras tareas del proyecto.
+
+Pruebas realizadas:
+```bash
+$ make tools
+Verificando herramientas necesarias...
+Todas las herramientas necesarias están disponibles
+
+$ echo $?
+0
+```
+
+### Decisiones Técnicas
+
+Para el Makefile se utilizó el prefijo `@` en los comandos para mantener la salida limpia y profesional. Se incluyó `.PHONY` para evitar conflictos con archivos del mismo nombre. Los targets `build`, `test`, `run` y `clean` están preparados como stubs para implementación en los siguientes sprints. La verificación de herramientas usa `command -v` que es POSIX-compliant y más confiable que `which`.
+
 ### Commits Realizados
 
 ```bash
+1412362 Agregar Makefile con tareas para verificar herramientas, construir, probar, ejecutar y limpiar el proyecto
 e1dceb7 Crear script base para gestión de procesos
 79f1bc1 Implementar funciones básicas de gestión de procesos
 ```


### PR DESCRIPTION
Se introduce un nuevo Makefile que proporciona una forma estandarizada de gestionar tareas de construcción, pruebas y configuración del entorno. La adición más significativa es el target tools que verifica la presencia de todas las utilidades Unix requeridas antes de permitir la ejecución de otras tareas, garantizando consistencia y confiabilidad en el entorno de desarrollo.

El Makefile incluye seis targets principales: tools, build, test, run, clean y help, con implementación completa del target tools usando command -v de manera POSIX-compliant. Los demás targets están preparados como stubs para implementación en futuros sprints. Se utiliza declaración .PHONY para prevenir conflictos y prefijo @ para salida limpia.

La documentación se actualiza en la bitácora del Sprint 1 incluyendo ejemplos de uso, decisiones técnicas y justificación del enfoque implementado. Los cambios cumplen con los requisitos del proyecto y establecen la base para automatización en siguientes iteraciones.